### PR TITLE
Use `enumerate` when you need both index and item.

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -86,8 +86,8 @@ outputList = itemsSold.values.tolist()
 outputjson = "{\"source_folder\": \"" + jsonFilesDir + "\", \"run_date\": \"" + str(date.today()) + "\", \"file_count\": " + str(fileCount) + ",\"best_sellers\": ["
 
 #append top sellers to the output json
-for i in range(len(outputList)):
-    outputjson = outputjson + "{\"product_id\": \"" + outputList[i][0] + "\", \"qty_sold\": " + str(outputList[i][1]) + ", \"rank\": " + str(i+1) + "},"
+for i, product in enumerate(outputList):
+    outputjson = outputjson + "{\"product_id\": \"" + product[0] + "\", \"qty_sold\": " + str(product[1]) + ", \"rank\": " + str(i+1) + "},"
 
 #removes last comma
 if outputjson.endswith(','):


### PR DESCRIPTION
And when you only need the item, just use
```python3
for product in outputList:
```

You can also break up items if you know exactly how many there are in each item. Don't forget the parens.
```python3
for i, (product_id, qty_sold) in enumerate(outputList):
```